### PR TITLE
turn constants into constants

### DIFF
--- a/nat_traversal/miniupnpc.nim
+++ b/nat_traversal/miniupnpc.nim
@@ -69,12 +69,13 @@ type
 ##################
 
 ##  MiniUPnPc return codes :
-importConst(UPNPCOMMAND_SUCCESS, "upnpcommands.h", cint)
-importConst(UPNPCOMMAND_UNKNOWN_ERROR, "upnpcommands.h", cint)
-importConst(UPNPCOMMAND_INVALID_ARGS, "upnpcommands.h", cint)
-importConst(UPNPCOMMAND_HTTP_ERROR, "upnpcommands.h", cint)
-importConst(UPNPCOMMAND_INVALID_RESPONSE, "upnpcommands.h", cint)
-importConst(UPNPCOMMAND_MEM_ALLOC_ERROR, "upnpcommands.h", cint)
+const
+  UPNPCOMMAND_SUCCESS* = cint(0)
+  UPNPCOMMAND_UNKNOWN_ERROR* = cint(-1)
+  UPNPCOMMAND_INVALID_ARGS* = cint(-2)
+  UPNPCOMMAND_HTTP_ERROR* = cint(-3)
+  UPNPCOMMAND_INVALID_RESPONSE* = cint(-4)
+  UPNPCOMMAND_MEM_ALLOC_ERROR* = cint(-5)
 
 proc UPNP_GetTotalBytesSent*(controlURL: cstring; servicetype: cstring): culonglong {.
     importc: "UPNP_GetTotalBytesSent", header: "upnpcommands.h".}
@@ -353,7 +354,6 @@ proc UPNP_GetPinholePackets*(controlURL: cstring; servicetype: cstring;
 ##  Structure to store the result of the parsing of UPnP
 ##  descriptions of Internet Gateway Devices
 const
-  # can't use importConst() here, because it needs to be available at compile time
   MINIUPNPC_URL_MAXSIZE* = (128)
 
 type
@@ -401,20 +401,22 @@ proc freeUPNPDevlist*(devlist: ptr UPNPDev) {.importc: "freeUPNPDevlist",
 ###############
 
 ##  error codes :
-importConst(UPNPDISCOVER_SUCCESS, "miniupnpc.h", cint)
-importConst(UPNPDISCOVER_UNKNOWN_ERROR, "miniupnpc.h", cint)
-importConst(UPNPDISCOVER_SOCKET_ERROR, "miniupnpc.h", cint)
-importConst(UPNPDISCOVER_MEMORY_ERROR, "miniupnpc.h", cint)
+const UPNPDISCOVER_SUCCESS* = cint(0)
+const UPNPDISCOVER_UNKNOWN_ERROR* = cint(-1)
+const UPNPDISCOVER_SOCKET_ERROR* = cint(-101)
+const UPNPDISCOVER_MEMORY_ERROR* = cint(-102)
 
 ##  versions :
+# We use importConst here because when a system header is used, we want the
+# number from the actual header file.
 importConst(MINIUPNPC_VERSION, "miniupnpc.h", cstring)
 importConst(MINIUPNPC_API_VERSION, "miniupnpc.h", cint)
 
 ##  Source port:
 ##    Using "1" as an alias for 1900 for backwards compatibility
 ##    (presuming one would have used that for the "sameport" parameter)
-importConst(UPNP_LOCAL_PORT_ANY, "miniupnpc.h", cint)
-importConst(UPNP_LOCAL_PORT_SAME, "miniupnpc.h", cint)
+const UPNP_LOCAL_PORT_ANY* = cint(0)
+const UPNP_LOCAL_PORT_SAME* = cint(1)
 
 ##  Structures definitions :
 type
@@ -591,28 +593,28 @@ type SentReceivedResult = Result[culonglong, cstring]
 
 proc totalBytesSent*(self: Miniupnp): SentReceivedResult =
   let res = UPNP_GetTotalBytesSent(self.urls.controlURL_CIF, addr(self.data.CIF.servicetype))
-  if res == UPNPCOMMAND_HTTP_ERROR.culonglong:
+  if res == cast[culonglong](UPNPCOMMAND_HTTP_ERROR):
     result.err(upnpError(res.cint))
   else:
     result.ok(res)
 
 proc totalBytesReceived*(self: Miniupnp): SentReceivedResult =
   let res = UPNP_GetTotalBytesReceived(self.urls.controlURL_CIF, addr(self.data.CIF.servicetype))
-  if res == UPNPCOMMAND_HTTP_ERROR.culonglong:
+  if res == cast[culonglong](UPNPCOMMAND_HTTP_ERROR):
     result.err(upnpError(res.cint))
   else:
     result.ok(res)
 
 proc totalPacketsSent*(self: Miniupnp): SentReceivedResult =
   let res = UPNP_GetTotalPacketsSent(self.urls.controlURL_CIF, addr(self.data.CIF.servicetype))
-  if res == UPNPCOMMAND_HTTP_ERROR.culonglong:
+  if res == cast[culonglong](UPNPCOMMAND_HTTP_ERROR):
     result.err(upnpError(res.cint))
   else:
     result.ok(res)
 
 proc totalPacketsReceived*(self: Miniupnp): SentReceivedResult =
   let res = UPNP_GetTotalPacketsReceived(self.urls.controlURL_CIF, addr(self.data.CIF.servicetype))
-  if res == UPNPCOMMAND_HTTP_ERROR.culonglong:
+  if res == cast[culonglong](UPNPCOMMAND_HTTP_ERROR):
     result.err(upnpError(res.cint))
   else:
     result.ok(res)

--- a/nat_traversal/natpmp.nim
+++ b/nat_traversal/natpmp.nim
@@ -10,7 +10,7 @@
 # headers and library location #
 ################################
 
-import ospaths, ./utils
+import os
 when defined(windows):
   import winlean
 else:
@@ -35,7 +35,7 @@ when defined(windows):
 {.passC: "-DENABLE_STRNATPMPERR".}
 
 ##  NAT-PMP Port as defined by the NAT-PMP draft
-importConst(NATPMP_PORT, "natpmp.h", cint)
+const NATPMP_PORT* = cint(5351)
 
 type
   PublicAddressStruct* {.importc: "struct no_name", header: "natpmp.h", bycopy.} = object
@@ -67,9 +67,10 @@ type
 
 
 ##  possible values for type field of natpmpresp_t
-importConst(NATPMP_RESPTYPE_PUBLICADDRESS, "natpmp.h", cint)
-importConst(NATPMP_RESPTYPE_UDPPORTMAPPING, "natpmp.h", cint)
-importConst(NATPMP_RESPTYPE_TCPPORTMAPPING, "natpmp.h", cint)
+const
+  NATPMP_RESPTYPE_PUBLICADDRESS* = cushort(0)
+  NATPMP_RESPTYPE_UDPPORTMAPPING* = cushort(1)
+  NATPMP_RESPTYPE_TCPPORTMAPPING* = cushort(2)
 
 ##  Values to pass to sendnewportmappingrequest()
 const
@@ -79,40 +80,40 @@ const
 ##  return values
 
 ##  NATPMP_ERR_INVALIDARGS : invalid arguments passed to the function
-importConst(NATPMP_ERR_INVALIDARGS, "natpmp.h", cint)
+const NATPMP_ERR_INVALIDARGS* = cint(-1)
 ##  NATPMP_ERR_SOCKETERROR : socket() failed. check errno for details
-importConst(NATPMP_ERR_SOCKETERROR, "natpmp.h", cint)
+const NATPMP_ERR_SOCKETERROR* = cint(-2)
 ##  NATPMP_ERR_CANNOTGETGATEWAY : can't get default gateway IP
-importConst(NATPMP_ERR_CANNOTGETGATEWAY, "natpmp.h", cint)
+const NATPMP_ERR_CANNOTGETGATEWAY* = cint(-3)
 ##  NATPMP_ERR_CLOSEERR : close() failed. check errno for details
-importConst(NATPMP_ERR_CLOSEERR, "natpmp.h", cint)
+const NATPMP_ERR_CLOSEERR* = cint(-4)
 ##  NATPMP_ERR_RECVFROM : recvfrom() failed. check errno for details
-importConst(NATPMP_ERR_RECVFROM, "natpmp.h", cint)
+const NATPMP_ERR_RECVFROM* = cint(-5)
 ##  NATPMP_ERR_NOPENDINGREQ : readnatpmpresponseorretry() called while no NAT-PMP request was pending
-importConst(NATPMP_ERR_NOPENDINGREQ, "natpmp.h", cint)
+const NATPMP_ERR_NOPENDINGREQ* = cint(-6)
 ##  NATPMP_ERR_NOGATEWAYSUPPORT : the gateway does not support NAT-PMP
-importConst(NATPMP_ERR_NOGATEWAYSUPPORT, "natpmp.h", cint)
+const NATPMP_ERR_NOGATEWAYSUPPORT* = cint(-7)
 ##  NATPMP_ERR_CONNECTERR : connect() failed. check errno for details
-importConst(NATPMP_ERR_CONNECTERR, "natpmp.h", cint)
+const NATPMP_ERR_CONNECTERR* = cint(-8)
 ##  NATPMP_ERR_WRONGPACKETSOURCE : packet not received from the network gateway
-importConst(NATPMP_ERR_WRONGPACKETSOURCE, "natpmp.h", cint)
+const NATPMP_ERR_WRONGPACKETSOURCE* = cint(-9)
 ##  NATPMP_ERR_SENDERR : send() failed. check errno for details
-importConst(NATPMP_ERR_SENDERR, "natpmp.h", cint)
+const NATPMP_ERR_SENDERR* = cint(-10)
 ##  NATPMP_ERR_FCNTLERROR : fcntl() failed. check errno for details
-importConst(NATPMP_ERR_FCNTLERROR, "natpmp.h", cint)
+const NATPMP_ERR_FCNTLERROR* = cint(-11)
 ##  NATPMP_ERR_GETTIMEOFDAYERR : gettimeofday() failed. check errno for details
-importConst(NATPMP_ERR_GETTIMEOFDAYERR, "natpmp.h", cint)
+const NATPMP_ERR_GETTIMEOFDAYERR* = cint(-12)
 
-importConst(NATPMP_ERR_UNSUPPORTEDVERSION, "natpmp.h", cint)
-importConst(NATPMP_ERR_UNSUPPORTEDOPCODE, "natpmp.h", cint)
+const NATPMP_ERR_UNSUPPORTEDVERSION* = cint(-14)
+const NATPMP_ERR_UNSUPPORTEDOPCODE* = cint(-15)
 
 ##  Errors from the server :
-importConst(NATPMP_ERR_UNDEFINEDERROR, "natpmp.h", cint)
-importConst(NATPMP_ERR_NOTAUTHORIZED, "natpmp.h", cint)
-importConst(NATPMP_ERR_NETWORKFAILURE, "natpmp.h", cint)
-importConst(NATPMP_ERR_OUTOFRESOURCES, "natpmp.h", cint)
+const NATPMP_ERR_UNDEFINEDERROR* = cint(-49)
+const NATPMP_ERR_NOTAUTHORIZED* = cint(-51)
+const NATPMP_ERR_NETWORKFAILURE* = cint(-52)
+const NATPMP_ERR_OUTOFRESOURCES* = cint(-53)
 ##  NATPMP_TRYAGAIN : no data available for the moment. try again later
-importConst(NATPMP_TRYAGAIN, "natpmp.h", cint)
+const NATPMP_TRYAGAIN* = cint(-100)
 
 ##  initnatpmp()
 ##  initialize a natpmp_t object

--- a/nat_traversal/utils.nim
+++ b/nat_traversal/utils.nim
@@ -27,4 +27,3 @@ macro importConst*(cname: untyped, cheader: string, ctype: untyped): untyped =
       )
     )
   )
-


### PR DESCRIPTION
* allows compiling without header file (`nlvm`)
* allows nim to inline constants
* constants in header are part of abi and won't change, this is safe