### PR TITLE
Support ARMv7 cross compilation

### DIFF
--- a/nat_traversal.nimble
+++ b/nat_traversal.nimble
@@ -11,14 +11,17 @@ installDirs   = @["vendor"]
 requires "nim >= 0.19.0", "stew"
 
 proc compileStaticLibraries() =
+  if getEnv("CC", "").len == 0:
+    putEnv("CC", "gcc")
+
   withDir "vendor/miniupnp/miniupnpc":
     when defined(windows):
-      exec("mingw32-make -f Makefile.mingw CC=gcc init libminiupnpc.a")
+      exec("mingw32-make -f Makefile.mingw init libminiupnpc.a")
     else:
       exec("make libminiupnpc.a")
   withDir "vendor/libnatpmp":
     when defined(windows):
-      exec("mingw32-make CC=gcc CFLAGS=\"-Wall -Os -DWIN32 -DNATPMP_STATICLIB -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4\" libnatpmp.a")
+      exec("mingw32-make CFLAGS=\"-Wall -Os -DWIN32 -DNATPMP_STATICLIB -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4\" libnatpmp.a")
     else:
       exec("make CFLAGS=\"-Wall -Os -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4\" libnatpmp.a")
 


### PR DESCRIPTION
First step towards https://github.com/status-im/nim-beacon-chain/issues/1086. I added a new task and an enum since define flags [aren't supported](https://github.com/nim-lang/nimble/issues/605), and using bools isn't scalable (ie adding ARMv8 support later). The checks are ordered with the assumption that supporting ARM cross compilation on Windows is out of scope. `-B` was added to force building since going back and forward between host and cross compilation requires a rebuild, and simply setting CC isn't enough.