### PR TITLE
bump `miniupnp` to `miniupnpc_2_2_4`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/miniupnp"]
 	ignore = dirty
-	branch = master
+	branch = status
 	path = vendor/miniupnp
 	url = https://github.com/status-im/miniupnp.git
 [submodule "vendor/libnatpmp-upstream"]


### PR DESCRIPTION
- https://github.com/miniupnp/miniupnp/blob/miniupnpc_2_2_4/miniupnpc/Changelog.txt

`miniupnpc_2_2_4` was already partially applied before