### PR TITLE
fix(build): include directory using `-iquote` instead of `-I`

### DIFF
--- a/nat_traversal/natpmp.nim
+++ b/nat_traversal/natpmp.nim
@@ -22,7 +22,7 @@ when defined(libnatpmpUseSystemLibs):
   {.passl: "-lnatpmp".}
 else:
   const includePath = currentSourcePath.parentDir().parentDir().replace('\\', '/') & "/vendor/libnatpmp-upstream"
-  {.passc: "-I" & includePath.}
+  {.passc: "-iquote " & includePath.}
   {.passl: includePath & "/libnatpmp.a".}
 
 when defined(windows):


### PR DESCRIPTION
On macos, the compiler is doing a case-insensitive search for a `version` header file, included with `#include <version>` in the macos sdk. Using `-I` causes `vendor/libnatpmp-upstream` to be included in the system header search path, so the compiler picks up `vendor/libnatpmp-upstream/VERSION`, causing a compilation error:
```
vendor/nim-nat-traversal/vendor/libnatpmp-upstream/version:1:1: error: expected unqualified-id
20120821
```

The [gcc 14.2 docs](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/cpp/Invocation.html#index-I) describe how `-iquote` alleviates this issue: 
> Directories specified with -iquote apply only to the quote form of the directive, #include "file". Directories specified with -I, -isystem, or -idirafter apply to lookup for both the #include "file" and #include <file> directives.

An alternative option is put files needed to be included in an `/include` directory, and use `-I` with that directory. An example of this is explained in https://stackoverflow.com/a/53155014.

More info can be found in similar issues:
- https://github.com/the-tcpdump-group/libpcap/issues/1331
- https://github.com/the-tcpdump-group/libpcap/issues/1100
- https://github.com/the-tcpdump-group/libpcap/issues/1043
- https://github.com/nmap/nmap/issues/2747